### PR TITLE
Removed unused variable n from CopyDump function

### DIFF
--- a/sectionfilter.cpp
+++ b/sectionfilter.cpp
@@ -117,7 +117,7 @@ inline int cIptvSectionFilter::Feed() {
 }
 
 int cIptvSectionFilter::CopyDump(const uint8_t *bufP, uint8_t lenP) {
-    uint16_t limit, seclen, n;
+    uint16_t limit, seclen;
 
     if (tsFeedpM >= eDmxMaxSectionFeedSize)
         return 0;
@@ -138,7 +138,7 @@ int cIptvSectionFilter::CopyDump(const uint8_t *bufP, uint8_t lenP) {
     // Always set secbuf
     secBufM = secBufBaseM + secBufpM;
 
-    for (n = 0; secBufpM + 2 < limit; ++n) {
+    for (; secBufpM + 2 < limit;) {
         seclen = GetLength(secBufM);
         if ((seclen <= 0) || (seclen > eDmxMaxSectionSize) || ((seclen + secBufpM) > limit))
             return 0;


### PR DESCRIPTION
Fixes:
```c++
CC sectionfilter.o g++ -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG  -fPIC -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -c -DPLUGIN_NAME_I18N='"iptv"' -DTS_ONLY_FULL_PACKETS=0 -DGITVERSION='"-GIT-8.95.002-21637-gbb9d880caf"'  -o sectionfilter.o sectionfilter.cpp sectionfilter.cpp: In member function 'int cIptvSectionFilter::CopyDump(const uint8_t*, uint8_t)': sectionfilter.cpp:120:29: warning: variable 'n' set but not used [-Wunused-but-set-variable=]
  120 |     uint16_t limit, seclen, n;
      |
```