### PR TITLE
Change X509_NAME pointer to const in httplib.h

### DIFF
--- a/http/cpp-httplib/httplib.h
+++ b/http/cpp-httplib/httplib.h
@@ -16533,7 +16533,7 @@ inline STACK_OF(X509_NAME) *
   X509 *cert = nullptr;
   while ((cert = PEM_read_bio_X509(bio, nullptr, nullptr, nullptr)) !=
          nullptr) {
-    X509_NAME *name = X509_get_subject_name(cert);
+    const X509_NAME *name = X509_get_subject_name(cert);
     if (name) { sk_X509_NAME_push(ca_list, X509_NAME_dup(name)); }
     X509_free(cert);
   }


### PR DESCRIPTION
Since OpenSSL 4.0, X509_get_subject_name returns const. ted with both OpenSSL 3.6.1 and 4.0.0.

Fixes:
```c++
http/cpp-httplib/httplib.h: In function 'stack_st_X509_NAME* httplib::tls::impl::create_client_ca_list_from_pem(const char*)': http/cpp-httplib/httplib.h:16536:44: error: invalid conversion from 'const X509_NAME*' {aka 'const X509_name_st*'} to 'X509_NAME*' {aka 'X509_name_st*'} [-fpermissive]
16536 |     X509_NAME *name = X509_get_subject_name(cert);
      |                       ~~~~~~~~~~~~~~~~~~~~~^~~~~~
      |                                            |
      |                                            const X509_NAME* {aka const X509_name_st*}
``` 