### PR TITLE
fix(http): suppress unused parameter warnings in ThrowAwayCallback

### DIFF
--- a/http/httpclient/HTTPClient.cpp
+++ b/http/httpclient/HTTPClient.cpp
@@ -900,8 +900,8 @@ inline void CHTTPClient::TrimSpaces(std::string& str)
 
 size_t CHTTPClient::ThrowAwayCallback(void* ptr, size_t size, size_t nmemb, void* data)
 {
-   reinterpret_cast<void*>(ptr);
-   reinterpret_cast<void*>(data);
+   (void)ptr;
+   (void)data;
 
    /* we are not interested in the headers itself,
    so we only return the size we would have saved ... */


### PR DESCRIPTION
Replace no-op reinterpret_cast<void*> with (void) casts for ptr and data parameters to properly suppress -Wunused-value warnings.